### PR TITLE
Remove nested DB session from journal (2025.1 backport)

### DIFF
--- a/networking_mlnx/journal/maintenance.py
+++ b/networking_mlnx/journal/maintenance.py
@@ -14,7 +14,6 @@
 #    under the License.
 
 from neutron_lib import context
-from neutron_lib.db import api as neutron_db_api
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_service import loopingcall
@@ -34,7 +33,6 @@ class MaintenanceThread(object):
     def start(self):
         self.timer.start(self.maintenance_interval, stop_on_exception=False)
 
-    @neutron_db_api.CONTEXT_READER
     def _execute_op(self, operation, context):
         op_details = operation.__name__
         if operation.__doc__:
@@ -43,7 +41,7 @@ class MaintenanceThread(object):
         try:
             LOG.info("Starting maintenance operation %s.", op_details)
             db.update_maintenance_operation(context, operation=operation)
-            operation(session=context.session)
+            operation(session=context)
             LOG.info("Finished maintenance operation %s.", op_details)
         except Exception:
             LOG.exception("Failed during maintenance operation %s.",


### PR DESCRIPTION
I am hitting errors like this in the logs:

  ERROR oslo.service.backend.eventlet.loopingcall
  AttributeError: 'method' object has
  no attribute '_enginefacade_context'

This appears to fix that, by removing the nested DB sessions. But I am not sure on what the intent was in the past, this certainly seems simpler. Although that session param probably needs a rename.

Change-Id: I53be4fc554e60f1c6291968110fffa1e4bafff96